### PR TITLE
Fix pathes for OSGI-INF.

### DIFF
--- a/org.opentestmodeling.vstep.ngt.sketch.parent/org.opentestmodeling.vstep.ngt.sketch.ide/build.properties
+++ b/org.opentestmodeling.vstep.ngt.sketch.parent/org.opentestmodeling.vstep.ngt.sketch.ide/build.properties
@@ -3,5 +3,5 @@ source.. = src/,\
            xtend-gen/
 bin.includes = .,\
                META-INF/,\
-               OSGI-INF/l10n/bundle.properties
+               OSGI-INF/
 bin.excludes = **/*.xtend

--- a/org.opentestmodeling.vstep.ngt.sketch.parent/org.opentestmodeling.vstep.ngt.sketch.tests/build.properties
+++ b/org.opentestmodeling.vstep.ngt.sketch.parent/org.opentestmodeling.vstep.ngt.sketch.tests/build.properties
@@ -3,5 +3,5 @@ source.. = src/,\
            xtend-gen/
 bin.includes = .,\
                META-INF/,\
-               OSGI-INF/l10n/bundle.properties
+               OSGI-INF/
 bin.excludes = **/*.xtend

--- a/org.opentestmodeling.vstep.ngt.sketch.parent/org.opentestmodeling.vstep.ngt.sketch.ui.tests/build.properties
+++ b/org.opentestmodeling.vstep.ngt.sketch.parent/org.opentestmodeling.vstep.ngt.sketch.ui.tests/build.properties
@@ -3,5 +3,5 @@ source.. = src/,\
            xtend-gen/
 bin.includes = .,\
                META-INF/,\
-               OSGI-INF/l10n/bundle.properties
+               OSGI-INF/
 bin.excludes = **/*.xtend

--- a/org.opentestmodeling.vstep.ngt.sketch.parent/org.opentestmodeling.vstep.ngt.sketch.ui/build.properties
+++ b/org.opentestmodeling.vstep.ngt.sketch.parent/org.opentestmodeling.vstep.ngt.sketch.ui/build.properties
@@ -4,5 +4,5 @@ source.. = src/,\
 bin.includes = .,\
                META-INF/,\
                plugin.xml,\
-               OSGI-INF/l10n/bundle.properties
+               OSGI-INF/
 bin.excludes = **/*.xtend

--- a/org.opentestmodeling.vstep.ngt.sketch.parent/org.opentestmodeling.vstep.ngt.sketch/build.properties
+++ b/org.opentestmodeling.vstep.ngt.sketch.parent/org.opentestmodeling.vstep.ngt.sketch/build.properties
@@ -5,7 +5,7 @@ bin.includes = model/generated/,\
                .,\
                META-INF/,\
                plugin.xml,\
-               OSGI-INF/l10n/bundle.properties
+               OSGI-INF/
 bin.excludes = **/*.mwe2,\
                **/*.xtend
 additional.bundles = org.eclipse.xtext.xbase,\


### PR DESCRIPTION
Eclipse shows warnings against `OSGI-INF/l10n/bundle.properties`.