### PR TITLE
Use Jetty as the container runtime image.

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,15 +1,20 @@
-FROM maven:3.6-jdk-8
+FROM maven:3.6-jdk-8 as emf-build
 
+RUN git clone -b R2_17_0 git://git.eclipse.org/gitroot/emf/org.eclipse.emf.git
+RUN git clone -b R2_17_0 git://git.eclipse.org/gitroot/xsd/org.eclipse.xsd.git
+WORKDIR org.eclipse.emf
+RUN mvn install
 
+FROM maven:3.6-jdk-8 as build
+
+COPY --from=emf-build /root/.m2/ /root/.m2/
 COPY org.opentestmodeling.vstep.ngt.sketch.parent/ apps/
 
 WORKDIR apps
 RUN mvn clean install -DskipTests
 
-EXPOSE 8080
+FROM jetty:9.4.18-jre8
 
-WORKDIR org.opentestmodeling.vstep.ngt.sketch.web
-RUN mvn org.apache.maven.plugins:maven-dependency-plugin:3.0.1:go-offline
+WORKDIR $JETTY_BASE
 
-CMD mvn jetty:run
-
+COPY --from=build /apps/org.opentestmodeling.vstep.ngt.sketch.web/target/org.opentestmodeling.vstep.ngt.sketch.web-0.0.1-SNAPSHOT.war webapps/ROOT.war


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>